### PR TITLE
getCacheObj returns null if object not found, caller handles error

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,6 +297,7 @@ class Dbscene extends EventEmitter {
 
 		try {
 			const cacheObj = await this.getCacheObj(parseInt(oscMessage.pathArr[4]));
+			if (cacheObj === null) return;
 			if (newX) cacheObj.x = newX;
 			if (newY) cacheObj.y = newY;
 			this.dbServer.emit('cacheUpdated', cacheObj);
@@ -430,6 +431,7 @@ class Dbscene extends EventEmitter {
 		const existingMapping = messageAddress[3];
 		const objNum = parseInt(messageAddress[4]);
 		const cacheObj = this.getCacheObj(objNum);
+		if (cacheObj === null) throw new Error(`Cache object ${objNum} does not exist`);
 
 		try {
 			await this.queryObjPos(cacheObj, existingMapping);
@@ -701,11 +703,7 @@ class Dbscene extends EventEmitter {
 	getCacheObj(objNum) {
 		const num = checkNum(objNum);
 		const cacheObj = this.cache.find((obj) => obj.num === num);
-
-		if (!cacheObj) {
-			throw new Error(`Cache object ${num} could not be found`);
-		}
-
+		if (!cacheObj) return null;
 		return cacheObj;
 	}
 
@@ -718,11 +716,13 @@ class Dbscene extends EventEmitter {
 		const num = checkNum(objNum);
 
 		const cacheObj = this.getCacheObj(num);
-		const configObjIndex = this.cache.indexOf(cacheObj);
+		if (cacheObj === null) {
+			console.error(`Cache object ${num} does not exist`);
+			return this.cache;
+		}
 
-		if (configObjIndex < 0) throw new Error('The cache object could not be found');
-		this.cache.splice(configObjIndex, 1);
-
+		const cacheObjIndex = this.cache.indexOf(cacheObj);
+		this.cache.splice(cacheObjIndex, 1);
 		return this.cache;
 	}
 
@@ -750,6 +750,7 @@ class Dbscene extends EventEmitter {
 		}
 
 		const cacheObj = await this.getCacheObj(num);
+		if (cacheObj === null) throw new Error(`New cache object was not created`);
 		return cacheObj;
 	}
 
@@ -762,6 +763,7 @@ class Dbscene extends EventEmitter {
 	async updateCacheObj(objNum, objNewName) {
 		const num = checkNum(objNum);
 		const cacheObj = await this.getCacheObj(num);
+		if (cacheObj === null) throw new Error(`Cache object ${num} does not exist`);
 
 		cacheObj.name = objNewName;
 

--- a/index.js
+++ b/index.js
@@ -297,7 +297,11 @@ class Dbscene extends EventEmitter {
 
 		try {
 			const cacheObj = await this.getCacheObj(parseInt(oscMessage.pathArr[4]));
-			if (cacheObj === null) return;
+			if (cacheObj === null) {
+				if (this.config.logging >= 2)
+					console.error(new Error(`Cache object ${oscMessage.pathArr[4]} does not exist`));
+				return;
+			}
 			if (newX) cacheObj.x = newX;
 			if (newY) cacheObj.y = newY;
 			this.dbServer.emit('cacheUpdated', cacheObj);


### PR DESCRIPTION
Previously, `getCacheObj` would throw an error if the object was not found.
With this change, `getCacheObj` returns `null` if object isn't found, leaving the caller to handle the issue.
Also, `receivedCoordinates` does not log an error if the object is not found in cache, and instead returns - this fixes #2.